### PR TITLE
fix: Expire cache after 1 day

### DIFF
--- a/src/apis/firefox-api.ts
+++ b/src/apis/firefox-api.ts
@@ -1,8 +1,11 @@
+import consola from "consola";
+
 export function createFirefoxApiClient() {
   return {
     getAddon: async (
       idOrSlugOrGuid: number | string
     ): Promise<Gql.FirefoxAddon> => {
+      consola.info("Fetching " + idOrSlugOrGuid);
       const url = new URL(
         `https://addons.mozilla.org/api/v5/addons/addon/${idOrSlugOrGuid}`
       );

--- a/src/services/chrome-service.ts
+++ b/src/services/chrome-service.ts
@@ -1,9 +1,13 @@
-import DataLoader from "dataloader";
 import { chrome } from "../crawlers";
+import { createCachedDataLoader, createInMemoryCache } from "../utils/cache";
+import { DAY_MS } from "../utils/time";
 
 export function createChromeService() {
-  const loader = new DataLoader<string, Gql.ChromeExtension | undefined>(
-    (ids) => Promise.all(ids.map((id) => chrome.crawlExtension(id, "en")))
+  const loader = createCachedDataLoader<
+    string,
+    Gql.ChromeExtension | undefined
+  >(DAY_MS, (ids) =>
+    Promise.all(ids.map((id) => chrome.crawlExtension(id, "en")))
   );
 
   return {

--- a/src/services/firefox-service.ts
+++ b/src/services/firefox-service.ts
@@ -1,12 +1,14 @@
-import DataLoader from "dataloader";
 import { createFirefoxApiClient } from "../apis";
+import { DAY_MS } from "../utils/time";
+import { createCachedDataLoader } from "../utils/cache";
 
 export function createFirefoxService() {
   const firefox = createFirefoxApiClient();
 
-  const loader = new DataLoader<string | number, Gql.FirefoxAddon | undefined>(
-    (ids) => Promise.all(ids.map((id) => firefox.getAddon(id)))
-  );
+  const loader = createCachedDataLoader<
+    string | number,
+    Gql.FirefoxAddon | undefined
+  >(DAY_MS, (ids) => Promise.all(ids.map((id) => firefox.getAddon(id))));
 
   return {
     getAddon: (id: string | number) => loader.load(id),

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,41 @@
+import DataLoader, { CacheMap } from "dataloader";
+
+export function createInMemoryCache<K, V>(config: {
+  ttl: number;
+}): CacheMap<K, V> {
+  const cache = new Map<K, CacheEntry<V>>();
+  return {
+    set(key, value) {
+      cache.set(key, {
+        setAt: Date.now(),
+        value,
+      });
+    },
+    get(key) {
+      const entry = cache.get(key);
+      if (entry === undefined) return undefined;
+      if (entry.setAt + config.ttl < Date.now()) return undefined;
+      return entry.value ?? undefined;
+    },
+    clear() {
+      cache.clear();
+    },
+    delete(key) {
+      cache.delete(key);
+    },
+  };
+}
+
+interface CacheEntry<T> {
+  setAt: number;
+  value: T | null;
+}
+
+export function createCachedDataLoader<K, V>(
+  ttl: number,
+  batchLoadFn: DataLoader.BatchLoadFn<K, V>
+) {
+  return new DataLoader(batchLoadFn, {
+    cacheMap: createInMemoryCache({ ttl }),
+  });
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,4 @@
+export const SECOND_MS = 1000;
+export const MINUTE_MS = 60 * SECOND_MS;
+export const HOUR_MS = 60 * MINUTE_MS;
+export const DAY_MS = 24 * HOUR_MS;


### PR DESCRIPTION
Currently, the cache is never cleared, and extension details are never queried again. This adds a TTL of 1 day for all extension detail caches.